### PR TITLE
Search should be case insensitive

### DIFF
--- a/templates/html.hbs
+++ b/templates/html.hbs
@@ -103,7 +103,7 @@
                               <i class="{{ ../baseSelector }} {{ ../classPrefix }}{{ this }} {{ ../classPrefix }}sm"></i>
                             </div>
                             <div class="cell">
-                              <code>{{ ../classPrefix }}sm</code>
+                              <code>.{{ ../classPrefix }}sm</code>
                             </div>
                           </div>
                         </li>
@@ -164,7 +164,7 @@
         $('.icon-preview-wrapper').show();
 
         if ($(this).val().length) {
-          var reg = new RegExp('w*' + $(this).val() + 'w*');
+          var reg = new RegExp('w*' + $(this).val() + 'w*', '\i');
           $('.{{ baseSelector }}')
             .filter(function() {
               if (!this.classList.value.match(reg)) {


### PR DESCRIPTION
Makes it easier to find icons when the list is big.
Added missing . (dot) on example for sm icon